### PR TITLE
Merge branch 'Macaulay2-patches'

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,12 @@
+To bump the version number, change it in these places:
+
+   doc/doxygen.conf
+	PROJECT_NUMBER         = 0.9.0
+
+   src/stdinc.cpp
+	const char* const version = "0.9.0";
+
+   test/messages/help-noparam.err
+        Frobby version 0.9.0 Copyright (C) 2007 Bjarke Hammersholt Roune
+
+


### PR DESCRIPTION
The last commit in the `Macaulay2-patches` branch (e86a22b, which has the `v0.9.1` tag) wasn't included in #3 and so was never merged into `master`.

Because of the version bump to 0.9.4 from `CoCoA-patches`, there were some conflicts, which I've resolved.

At some point, we should probably bump the frobby version to 0.9.5.