### PR TITLE
[C++17] Use std::shuffle instead of std::random_shuffle.

### DIFF
--- a/src/IdealOrderer.cpp
+++ b/src/IdealOrderer.cpp
@@ -26,6 +26,7 @@
 #include "ElementDeleter.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <iterator>
 #include <map>
 
@@ -52,8 +53,15 @@ namespace {
   public:
     static const char* staticGetName() {return "random";}
   private:
+    struct URBG {
+        using result_type = int;
+        static constexpr int min() { return 0; }
+        static constexpr int max() { return RAND_MAX; }
+        int operator()() const { return std::rand(); }
+    };
     void doOrder(Ideal& ideal) const {
-      random_shuffle(ideal.begin(), ideal.end());
+      URBG g;
+      std::shuffle(ideal.begin(), ideal.end(), g);
     }
   };
 


### PR DESCRIPTION
`std::random_shuffle` no longer exists, as of C++17; and it was never okay to call it unqualified, anyway.

After this patch, I can do `make test` with Clang and libc++, with the compiler flags `-std=c++17 -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR`.