### PR TITLE
[C++17] Remove call to std::set_unexpected.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,8 +77,10 @@ void frobbyUnexpected() {
 */
 int main(int argc, const char** argv) {
   try {
-    set_terminate(frobbyTerminate);
-    set_unexpected(frobbyUnexpected);
+    std::set_terminate(frobbyTerminate);
+#if __cplusplus < 201700L
+    std::set_unexpected(frobbyUnexpected);
+#endif
 
     srand((unsigned int)time(0) +
 #ifdef __GNUC__ // Only GCC defines this macro.


### PR DESCRIPTION
"Unexpected" exceptions can only be thrown if you have
dynamic exception specifications, which were removed from the
language in C++17 (and deprecated since C++11). This library
function was also removed in C++17.

Drive-by qualify these two library function calls.