### PR TITLE
[C++11] Use std::move when moving-from auto_ptr.

### DIFF
--- a/src/BigTermRecorder.cpp
+++ b/src/BigTermRecorder.cpp
@@ -32,12 +32,12 @@ void BigTermRecorder::consumeRing(const VarNames& names) {
 
 void BigTermRecorder::consume(auto_ptr<BigIdeal> ideal) {
   consumeRing(ideal->getNames());
-  exceptionSafePushBack(_ideals, ideal);
+  exceptionSafePushBack(_ideals, std::move(ideal));
 }
 
 void BigTermRecorder::beginConsuming() {
   auto_ptr<BigIdeal> ideal(new BigIdeal(_names));
-  exceptionSafePushBack(_ideals, ideal);
+  exceptionSafePushBack(_ideals, std::move(ideal));
 }
 
 void BigTermRecorder::consume

--- a/src/BigattiFacade.cpp
+++ b/src/BigattiFacade.cpp
@@ -41,7 +41,7 @@ void BigattiFacade::computeMultigradedHilbertSeries() {
   BigattiHilbertAlgorithm alg(_common.takeIdeal(),
                               _common.getTranslator(),
                               _params,
-                              _pivot,
+                              std::move(_pivot),
                               _common.getPolyConsumer());
   alg.setComputeUnivariate(false);
   alg.run();
@@ -55,7 +55,7 @@ void BigattiFacade::computeUnivariateHilbertSeries() {
   BigattiHilbertAlgorithm alg(_common.takeIdeal(),
                               _common.getTranslator(),
                               _params,
-                              _pivot,
+                              std::move(_pivot),
                               _common.getPolyConsumer());
   alg.setComputeUnivariate(true);
   alg.run();

--- a/src/BigattiHilbertAlgorithm.cpp
+++ b/src/BigattiHilbertAlgorithm.cpp
@@ -32,7 +32,7 @@ BigattiHilbertAlgorithm
  _translator(translator),
  _consumer(&consumer),
  _baseCase(translator),
- _pivot(pivot),
+ _pivot(std::move(pivot)),
  _computeUnivariate(false),
  _params(params) {
 
@@ -85,7 +85,7 @@ void BigattiHilbertAlgorithm::processState(auto_ptr<BigattiState> state) {
     _baseCase.genericBaseCase(*state) :
     _baseCase.baseCase(*state);
   if (isBaseCase) {
-    freeState(state);
+    freeState(std::move(state));
     return;
   }
 
@@ -124,5 +124,5 @@ void BigattiHilbertAlgorithm::simplify(BigattiState& state) {
 
 void BigattiHilbertAlgorithm::freeState(auto_ptr<BigattiState> state) {
   state->getIdeal().clear(); // To preserve memory
-  _stateCache.freeObject(state);
+  _stateCache.freeObject(std::move(state));
 }

--- a/src/BigattiPivotStrategy.cpp
+++ b/src/BigattiPivotStrategy.cpp
@@ -388,7 +388,7 @@ namespace {
   class WidenPivot : public BigattiPivotStrategy {
   public:
     WidenPivot(auto_ptr<BigattiPivotStrategy> strategy):
-      _strategy(strategy) {
+      _strategy(std::move(strategy)) {
       _name = _strategy->getName();
       _name += " (wide)";
     }
@@ -443,7 +443,7 @@ createStrategy(const string& prefix, bool widen) {
   ASSERT(strategy.get() != 0);
 
   if (widen)
-    strategy = auto_ptr<BigattiPivotStrategy>(new WidenPivot(strategy));
+    strategy = auto_ptr<BigattiPivotStrategy>(new WidenPivot(std::move(strategy)));
 
   return strategy;
 }

--- a/src/CanonicalCoefTermConsumer.cpp
+++ b/src/CanonicalCoefTermConsumer.cpp
@@ -21,7 +21,7 @@
 
 CanonicalCoefTermConsumer::
 CanonicalCoefTermConsumer(auto_ptr<CoefTermConsumer> consumer):
-  _consumer(consumer) {
+  _consumer(std::move(consumer)) {
   ASSERT(_consumer.get() != 0);
 }
 

--- a/src/CanonicalTermConsumer.cpp
+++ b/src/CanonicalTermConsumer.cpp
@@ -28,7 +28,7 @@ CanonicalTermConsumer::CanonicalTermConsumer(auto_ptr<TermConsumer> consumer,
   _storingList(false),
   _ideals(),
   _idealsDeleter(_ideals),
-  _consumer(consumer),
+  _consumer(std::move(consumer)),
   _translator(translator) {
   ASSERT(_consumer.get() != 0);
 }
@@ -48,7 +48,7 @@ void CanonicalTermConsumer::beginConsuming() {
   ASSERT(_storingList || _ideals.empty());
 
   auto_ptr<Ideal> ideal(new Ideal(_varCount));
-  exceptionSafePushBack(_ideals, ideal);
+  exceptionSafePushBack(_ideals, std::move(ideal));
 }
 
 void CanonicalTermConsumer::consume(const Term& term) {

--- a/src/CliParams.cpp
+++ b/src/CliParams.cpp
@@ -32,7 +32,7 @@ namespace {
   ParamNames getParamNames(vector<Parameter*> params) {
     struct HoldsFunction {
       static auto_ptr<Dummy> dummyCreate() {
-        return auto_ptr<Dummy>(0);
+        return auto_ptr<Dummy>();
       }
     };
 
@@ -88,7 +88,7 @@ void CliParams::processOption(const string& optionName,
 void CliParams::add(auto_ptr<Parameter> param) {
   ASSERT(!hasParam(param->getName()));
   Parameter& paramRef = *param;
-  exceptionSafePushBack(_ownedParams, param);
+  exceptionSafePushBack(_ownedParams, std::move(param));
   add(paramRef);
 }
 

--- a/src/ColumnPrinter.cpp
+++ b/src/ColumnPrinter.cpp
@@ -55,7 +55,7 @@ void ColumnPrinter::addColumn(bool flushLeft,
   col->suffix = suffix;
   col->flushLeft = flushLeft;
 
-  exceptionSafePushBack(_cols, col);
+  exceptionSafePushBack(_cols, std::move(col));
 }
 
 size_t ColumnPrinter::getColumnCount() const {

--- a/src/CommonParamsHelper.cpp
+++ b/src/CommonParamsHelper.cpp
@@ -132,14 +132,14 @@ makeTranslatedIdealConsumer(bool split) {
     auto_ptr<BigTermConsumer> splitter
       (new IrreducibleIdealSplitter(*_idealConsumer));
     translated.reset
-      (new TranslatingTermConsumer(splitter, getTranslator()));
+      (new TranslatingTermConsumer(std::move(splitter), getTranslator()));
   } else
     translated.reset
       (new TranslatingTermConsumer(*_idealConsumer, getTranslator()));
 
   if (_produceCanonicalOutput) {
     return auto_ptr<TermConsumer>
-      (new CanonicalTermConsumer(translated,
+      (new CanonicalTermConsumer(std::move(translated),
                                  getIdeal().getVarCount(),
                                  &getTranslator()));
   } else
@@ -151,7 +151,7 @@ auto_ptr<CoefTermConsumer> CommonParamsHelper::makeTranslatedPolyConsumer() {
     (new TranslatingCoefTermConsumer(*_polyConsumer, getTranslator()));
   if (_produceCanonicalOutput)
     return auto_ptr<CoefTermConsumer>
-      (new CanonicalCoefTermConsumer(translated));
+      (new CanonicalCoefTermConsumer(std::move(translated)));
   else
     return translated;
 }

--- a/src/CommonParamsHelper.h
+++ b/src/CommonParamsHelper.h
@@ -64,12 +64,12 @@ class CommonParamsHelper {
 
   Ideal& getIdeal() {return *_ideal;}
   const Ideal& getIdeal() const {return *_ideal;}
-  auto_ptr<Ideal> takeIdeal() {return _ideal;}
+  auto_ptr<Ideal> takeIdeal() {return std::move(_ideal);}
   bool hasIdeal() const {return _ideal.get() != 0;}
 
   TermTranslator& getTranslator() {return *_translator;}
   const TermTranslator& getTranslator() const {return *_translator;}
-  auto_ptr<TermTranslator> takeTranslator() {return _translator;}
+  auto_ptr<TermTranslator> takeTranslator() {return std::move(_translator);}
 
   BigTermConsumer& getIdealConsumer() {return *_idealConsumer;}
 

--- a/src/DebugStrategy.cpp
+++ b/src/DebugStrategy.cpp
@@ -41,7 +41,7 @@ void DebugStrategy::run(const Ideal& ideal) {
 bool DebugStrategy::processSlice(TaskEngine& tasks, auto_ptr<Slice> slice) {
   fputs("DEBUG: Processing slice.\n", _out);
   slice->print(stderr);
-  bool wasBaseCase = _strategy->processSlice(tasks, slice);
+  bool wasBaseCase = _strategy->processSlice(tasks, std::move(slice));
   if (wasBaseCase)
     fputs("DEBUG: Determined that slice is base case.\n", _out);
   else
@@ -71,5 +71,5 @@ bool DebugStrategy::getUseSimplification() const {
 
 void DebugStrategy::freeSlice(auto_ptr<Slice> slice) {
   fputs("DEBUG: Freeing slice.\n", _out);
-  _strategy->freeSlice(slice);
+  _strategy->freeSlice(std::move(slice));
 }

--- a/src/ElementDeleter.h
+++ b/src/ElementDeleter.h
@@ -140,7 +140,7 @@ void exceptionSafePushBack(Container& container, auto_ptr<Element> pointer) {
 template<class Container, class Element>
 void noThrowPushBack(Container& container, auto_ptr<Element> pointer) throw () {
   try {
-    exceptionSafePushBack(container, pointer);
+    exceptionSafePushBack(container, std::move(pointer));
   } catch (const bad_alloc&) {
     // Ignore the exception.
   }

--- a/src/EulerAction.cpp
+++ b/src/EulerAction.cpp
@@ -180,22 +180,22 @@ void EulerAction::perform() {
   auto_ptr<PivotStrategy> genStrat = newGenPivotStrategy(_genPivot.getValue());
   auto_ptr<PivotStrategy> strat;
   if (_pivot == "std")
-	strat = stdStrat;
+	strat = std::move(stdStrat);
   else if (_pivot == "gen")
-	strat = genStrat;
+	strat = std::move(genStrat);
   else if (_pivot == "hybrid")
-	strat = newHybridPivotStrategy(stdStrat, genStrat);
+	strat = newHybridPivotStrategy(std::move(stdStrat), std::move(genStrat));
   else
     reportError("Unknown kind of pivot strategy \"" +
 				_pivot.getValue() + "\".");
 
   if (_printDebug)
-	strat = newDebugPivotStrategy(strat, stderr);
+	strat = newDebugPivotStrategy(std::move(strat), stderr);
   if (_printStatistics)
-	strat = newStatisticsPivotStrategy(strat, stderr);
+	strat = newStatisticsPivotStrategy(std::move(strat), stderr);
 
   PivotEulerAlg alg;
-  alg.setPivotStrategy(strat);
+  alg.setPivotStrategy(std::move(strat));
   alg.setUseUniqueDivSimplify(_useUniqueDivSimplify);
   alg.setUseManyDivSimplify(_useManyDivSimplify);
   alg.setUseAllPairsSimplify(_useAllPairsSimplify);

--- a/src/Fourti2IOHandler.cpp
+++ b/src/Fourti2IOHandler.cpp
@@ -166,13 +166,13 @@ namespace IO {
   BigTermConsumer* Fourti2IOHandler::doCreateIdealWriter(FILE* out) {
     F::display4ti2Warning();
     auto_ptr<BigTermConsumer> writer(new Fourti2IdealWriter(out));
-    return new IdealConsolidator(writer);
+    return new IdealConsolidator(std::move(writer));
   }
 
   CoefBigTermConsumer* Fourti2IOHandler::doCreatePolynomialWriter(FILE* out) {
     F::display4ti2Warning();
     auto_ptr<CoefBigTermConsumer> writer(new Fourti2PolyWriter(out));
-    return new PolynomialConsolidator(writer);
+    return new PolynomialConsolidator(std::move(writer));
   }
 
   void Fourti2IOHandler::doWriteTerm(const vector<mpz_class>& term,

--- a/src/HilbertBasecase.cpp
+++ b/src/HilbertBasecase.cpp
@@ -166,7 +166,7 @@ void HilbertBasecase::computeCoefficient(Ideal& originalIdeal) {
         break;
 
       if (entryIdealDeleter.get() != 0)
-        freeIdeal(entryIdealDeleter);
+        freeIdeal(std::move(entryIdealDeleter));
       entry = _todo.back();
       _todo.pop_back();
 
@@ -286,5 +286,5 @@ void HilbertBasecase::freeIdeal(auto_ptr<Ideal> ideal) {
   ASSERT(ideal.get() != 0);
 
   ideal->clear();
-  exceptionSafePushBack(_idealCache, ideal);
+  exceptionSafePushBack(_idealCache, std::move(ideal));
 }

--- a/src/HilbertStrategy.cpp
+++ b/src/HilbertStrategy.cpp
@@ -69,15 +69,15 @@ bool HilbertStrategy::processSlice
   ASSERT(debugIsValidSlice(slice.get()));
 
   if (slice->baseCase(getUseSimplification())) {
-    freeSlice(slice);
+    freeSlice(std::move(slice));
     return true;
   }
 
   if (getUseIndependence() && _indepSplitter.analyze(*slice)) {
-    independenceSplit(slice);
+    independenceSplit(std::move(slice));
   } else {
     ASSERT(_split->isPivotSplit());
-    pivotSplit(auto_ptr<Slice>(slice));
+    pivotSplit(std::move(slice));
   }
 
   return false;
@@ -113,7 +113,7 @@ void HilbertStrategy::freeConsumer(auto_ptr<HilbertIndependenceConsumer>
          _consumerCache.end());
 
   consumer->clear();
-  noThrowPushBack(_consumerCache, consumer);
+  noThrowPushBack(_consumerCache, std::move(consumer));
 }
 
 void HilbertStrategy::independenceSplit(auto_ptr<Slice> sliceParam) {
@@ -141,7 +141,7 @@ void HilbertStrategy::independenceSplit(auto_ptr<Slice> sliceParam) {
   _tasks.addTask(rightSlice.release());
 
   // Deal with slice.
-  freeSlice(auto_ptr<Slice>(slice));
+  freeSlice(std::move(slice));
 }
 
 auto_ptr<HilbertIndependenceConsumer> HilbertStrategy::newConsumer() {

--- a/src/IOParameters.cpp
+++ b/src/IOParameters.cpp
@@ -26,9 +26,7 @@
 
 IOParameters::IOParameters(const DataType& input, const DataType& output):
   _inputType(input),
-  _outputType(output),
-  _inputFormat(0),
-  _outputFormat(0) {
+  _outputType(output) {
 
   string inputFormats;
   string outputFormats;

--- a/src/IdealConsolidator.cpp
+++ b/src/IdealConsolidator.cpp
@@ -21,7 +21,7 @@
 #include "TermTranslator.h"
 
 IdealConsolidator::IdealConsolidator(auto_ptr<BigTermConsumer> consumer):
-  _consumer(consumer),
+  _consumer(std::move(consumer)),
   _inList(false),
   _inIdeal(false) {
 }

--- a/src/IdealOrderer.cpp
+++ b/src/IdealOrderer.cpp
@@ -199,7 +199,7 @@ namespace {
    constructor. */
   class ReverseOrderer : public IdealOrderer {
   public:
-    ReverseOrderer(auto_ptr<IdealOrderer> orderer): _orderer(orderer) {}
+    ReverseOrderer(auto_ptr<IdealOrderer> orderer): _orderer(std::move(orderer)) {}
 
   private:
     virtual void doOrder(Ideal& ideal) const {
@@ -218,7 +218,7 @@ namespace {
     CompositeOrderer(): _orderersDeleter(_orderers) {}
 
     void refineOrderingWith(auto_ptr<IdealOrderer> orderer) {
-      exceptionSafePushBack(_orderers, orderer);
+      exceptionSafePushBack(_orderers, std::move(orderer));
     }
 
   private:
@@ -263,7 +263,7 @@ namespace {
     if (prefix.substr(0, 3) == "rev") {
       auto_ptr<IdealOrderer> orderer =
         createWithPrefix(getOrdererFactory(), prefix.substr(3));
-      return auto_ptr<IdealOrderer>(new ReverseOrderer(orderer));
+      return auto_ptr<IdealOrderer>(new ReverseOrderer(std::move(orderer)));
     } else
       return createWithPrefix(getOrdererFactory(), prefix);
   }

--- a/src/InputConsumer.cpp
+++ b/src/InputConsumer.cpp
@@ -192,9 +192,9 @@ void InputConsumer::endIdeal() {
   ASSERT(_inIdeal);
   _inIdeal = false;
   auto_ptr<Entry> entry(new Entry());
-  entry->_big = _bigIdeal;
-  entry->_sqf = _sqfIdeal;
-  exceptionSafePushBack(_ideals, entry);
+  entry->_big = std::move(_bigIdeal);
+  entry->_sqf = std::move(_sqfIdeal);
+  exceptionSafePushBack(_ideals, std::move(entry));
 }
 
 void InputConsumer::releaseIdeal(auto_ptr<SquareFreeIdeal>& sqf, auto_ptr<BigIdeal>& big) {
@@ -202,8 +202,8 @@ void InputConsumer::releaseIdeal(auto_ptr<SquareFreeIdeal>& sqf, auto_ptr<BigIde
   ASSERT(!empty());
   Entry entry;
   releaseIdeal(entry);
-  sqf = entry._sqf;
-  big = entry._big;
+  sqf = std::move(entry._sqf);
+  big = std::move(entry._big);
 }
 
 auto_ptr<BigIdeal> InputConsumer::releaseBigIdeal() {
@@ -212,7 +212,7 @@ auto_ptr<BigIdeal> InputConsumer::releaseBigIdeal() {
   Entry entry;
   releaseIdeal(entry);
   toBigIdeal(entry._sqf, entry._big);
-  return entry._big;
+  return std::move(entry._big);
 }
 
 auto_ptr<SquareFreeIdeal> InputConsumer::releaseSquareFreeIdeal() {
@@ -221,13 +221,13 @@ auto_ptr<SquareFreeIdeal> InputConsumer::releaseSquareFreeIdeal() {
   ASSERT(_ideals.front()->_sqf.get() != 0);
   Entry entry;
   releaseIdeal(entry);
-  return entry._sqf;
+  return std::move(entry._sqf);
 }
 
 void InputConsumer::releaseIdeal(Entry& entry) {
   ASSERT(!_inIdeal);
   ASSERT(!empty());
-  entry = *_ideals.front();
+  entry = std::move(*_ideals.front());
   _ideals.pop_front();
 }
 

--- a/src/IntersectFacade.cpp
+++ b/src/IntersectFacade.cpp
@@ -58,7 +58,7 @@ auto_ptr<BigIdeal> IntersectFacade::intersect(const vector<BigIdeal*>& ideals,
     ::intersect(tmp.get(), intersection.get(), ideals2[i]);
 
     // Handle bookkeeping
-    intersection = tmp;
+    intersection = std::move(tmp);
   }
 
   auto_ptr<BigIdeal> bigIdeal(new BigIdeal(names));

--- a/src/IrreducibleIdealSplitter.cpp
+++ b/src/IrreducibleIdealSplitter.cpp
@@ -29,7 +29,7 @@ IrreducibleIdealSplitter::IrreducibleIdealSplitter
 IrreducibleIdealSplitter::IrreducibleIdealSplitter
 (auto_ptr<BigTermConsumer> consumer):
   _consumer(*consumer),
-  _consumerDeleter(consumer),
+  _consumerDeleter(std::move(consumer)),
   _inList(false) {
 }
 

--- a/src/MsmStrategy.cpp
+++ b/src/MsmStrategy.cpp
@@ -28,8 +28,7 @@
 MsmStrategy::MsmStrategy(TermConsumer* consumer,
                          const SplitStrategy* splitStrategy):
   SliceStrategyCommon(splitStrategy),
-  _consumer(consumer),
-  _initialSubtract(0) {
+  _consumer(consumer) {
   ASSERT(consumer != 0);
 }
 
@@ -69,17 +68,17 @@ bool MsmStrategy::processSlice(TaskEngine& tasks, auto_ptr<Slice> slice) {
   ASSERT(slice.get() != 0);
 
   if (slice->baseCase(getUseSimplification())) {
-    freeSlice(slice);
+    freeSlice(std::move(slice));
     return true;
   }
 
   if (getUseIndependence() && _indep.analyze(*slice))
-    independenceSplit(slice);
+    independenceSplit(std::move(slice));
   else if (_split->isLabelSplit())
-    labelSplit(slice);
+    labelSplit(std::move(slice));
   else {
     ASSERT(_split->isPivotSplit());
-    pivotSplit(auto_ptr<Slice>(slice));
+    pivotSplit(std::move(slice));
   }
 
   return false;
@@ -280,7 +279,7 @@ void MsmStrategy::independenceSplit(auto_ptr<Slice> sliceParam) {
   _tasks.addTask(rightSlice.release());
 
   // Deal with slice.
-  freeSlice(auto_ptr<Slice>(slice));
+  freeSlice(std::move(slice));
 }
 
 void MsmStrategy::getPivot(Term& pivot, Slice& slice) {

--- a/src/ObjectCache.h
+++ b/src/ObjectCache.h
@@ -91,7 +91,7 @@ void ObjectCache<T>::freeObject(auto_ptr<S> object) {
   ASSERT(dynamic_cast<T*>(object.get()) != 0);
 
   auto_ptr<T> casted(static_cast<T*>(object.release()));
-  noThrowPushBack(_cache, casted);
+  noThrowPushBack(_cache, std::move(casted));
 }
 
 #endif

--- a/src/PivotEulerAlg.h
+++ b/src/PivotEulerAlg.h
@@ -36,7 +36,7 @@ class PivotEulerAlg {
   const mpz_class& getComputedEulerCharacteristic() const {return _euler;}
 
   void setPivotStrategy(auto_ptr<PivotStrategy> strategy) {
-	_pivotStrategy = strategy;
+	_pivotStrategy = std::move(strategy);
   }
 
   void setInitialAutoTranspose(bool value) {_initialAutoTranspose = value;}

--- a/src/PivotStrategy.cpp
+++ b/src/PivotStrategy.cpp
@@ -265,7 +265,7 @@ namespace {
   class StdWiden  : public WithPivotTerm {
   public:
 	StdWiden(auto_ptr<StdStrategy> strat):
-	  _strat(strat) {
+	  _strat(std::move(strat)) {
 	  ASSERT(_strat.get() != 0);
 	}
 
@@ -444,7 +444,7 @@ namespace {
 	typedef RawSquareFreeIdeal::iterator iterator;
 
 	void addStrategy(auto_ptr<GenStrategy> strat) {
-	  exceptionSafePushBack(_filters, strat);
+	  exceptionSafePushBack(_filters, std::move(strat));
 	}
 
 	virtual EulerState* doPivot(EulerState& state, const size_t* divCounts) {
@@ -741,7 +741,7 @@ namespace {
   public:
 	HybridPivotStrategy(auto_ptr<PivotStrategy> stdStrat,
 						auto_ptr<PivotStrategy> genStrat):
-	  _stdStrat(stdStrat), _genStrat(genStrat) {}
+	  _stdStrat(std::move(stdStrat)), _genStrat(std::move(genStrat)) {}
 
 	virtual EulerState* doPivot(EulerState& state, const size_t* divCounts) {
 	  if (state.getNonEliminatedVarCount() <
@@ -776,7 +776,7 @@ namespace {
   class DebugStrategy : public PivotStrategy {
   public:
 	DebugStrategy(auto_ptr<PivotStrategy> strat, FILE* out):
-	  _strat(strat), _out(out) {}
+	  _strat(std::move(strat)), _out(out) {}
 
 	virtual EulerState* doPivot(EulerState& state,
 						 const size_t* divCounts) {
@@ -825,7 +825,7 @@ namespace {
   class StatisticsStrategy : public PivotStrategy {
   public:
 	StatisticsStrategy(auto_ptr<PivotStrategy> strat, FILE* out):
-	  _strat(strat), _out(out), _statesSplit(0), _transposes(0) {}
+	  _strat(std::move(strat)), _out(out), _statesSplit(0), _transposes(0) {}
 
 	virtual EulerState* doPivot(EulerState& state, const size_t* divCounts) {
 	  ++_statesSplit;
@@ -910,7 +910,7 @@ auto_ptr<PivotStrategy> newStdPivotStrategy(const string& name) {
 
   auto_ptr<StdStrategy> subStrat =
 	getStdStratFactory().create(name.substr(6, name.size() - 6));
-  return auto_ptr<PivotStrategy>(new StdWiden(subStrat));
+  return auto_ptr<PivotStrategy>(new StdWiden(std::move(subStrat)));
 }
 
 auto_ptr<PivotStrategy> newGenPivotStrategy(const string& name) {
@@ -935,25 +935,25 @@ auto_ptr<PivotStrategy> newGenPivotStrategy(const string& name) {
 	}
 
 	auto_ptr<GenStrategy> strat = factory.create(part);
-	composite->addStrategy(strat);
+	composite->addStrategy(std::move(strat));
   } while (pos != string::npos);
   return auto_ptr<PivotStrategy>(composite.release());
 }
 
 auto_ptr<PivotStrategy> newHybridPivotStrategy
 (auto_ptr<PivotStrategy> stdStrat, auto_ptr<PivotStrategy> genStrat) {
-  PivotStrategy* strat = new HybridPivotStrategy(stdStrat, genStrat);
+  PivotStrategy* strat = new HybridPivotStrategy(std::move(stdStrat), std::move(genStrat));
   return auto_ptr<PivotStrategy>(strat);
 }
 
 auto_ptr<PivotStrategy> newDebugPivotStrategy(auto_ptr<PivotStrategy> strat,
 											  FILE* out) {
-  return auto_ptr<PivotStrategy>(new DebugStrategy(strat, out));
+  return auto_ptr<PivotStrategy>(new DebugStrategy(std::move(strat), out));
 }
 
 auto_ptr<PivotStrategy> newStatisticsPivotStrategy
 (auto_ptr<PivotStrategy> strat, FILE* out) {
-  return auto_ptr<PivotStrategy>(new StatisticsStrategy(strat, out));
+  return auto_ptr<PivotStrategy>(new StatisticsStrategy(std::move(strat), out));
 }
 
 auto_ptr<PivotStrategy> newDefaultPivotStrategy() {

--- a/src/PolynomialConsolidator.cpp
+++ b/src/PolynomialConsolidator.cpp
@@ -19,7 +19,7 @@
 
 PolynomialConsolidator::PolynomialConsolidator
 (auto_ptr<CoefBigTermConsumer> consumer):
-  _consumer(consumer) {
+  _consumer(std::move(consumer)) {
 }
 
 void PolynomialConsolidator::consumeRing(const VarNames& names) {

--- a/src/ScarfFacade.cpp
+++ b/src/ScarfFacade.cpp
@@ -46,8 +46,8 @@ void ScarfFacade::computeMultigradedHilbertSeries() {
 
   ScarfHilbertAlgorithm alg(_helper.getTranslator(),
                             _params,
-                            _enumerationOrder,
-                            _deformationOrder);
+                            std::move(_enumerationOrder),
+                            std::move(_deformationOrder));
 
   alg.runGeneric(_helper.getIdeal(),
                  _helper.getPolyConsumer(),
@@ -62,8 +62,8 @@ void ScarfFacade::computeUnivariateHilbertSeries() {
 
   ScarfHilbertAlgorithm alg(_helper.getTranslator(),
                             _params,
-                            _enumerationOrder,
-                            _deformationOrder);
+                            std::move(_enumerationOrder),
+                            std::move(_deformationOrder));
 
   alg.runGeneric(_helper.getIdeal(),
                  _helper.getPolyConsumer(),

--- a/src/ScarfHilbertAlgorithm.cpp
+++ b/src/ScarfHilbertAlgorithm.cpp
@@ -96,8 +96,8 @@ ScarfHilbertAlgorithm::ScarfHilbertAlgorithm
  auto_ptr<IdealOrderer> deformationOrder):
   _translator(translator),
   _params(params),
-  _enumerationOrder(enumerationOrder),
-  _deformationOrder(deformationOrder),
+  _enumerationOrder(std::move(enumerationOrder)),
+  _deformationOrder(std::move(deformationOrder)),
   _totalStates(0),
   _totalFaces(0) {
   ASSERT(_enumerationOrder.get() != 0);

--- a/src/SliceStrategyCommon.cpp
+++ b/src/SliceStrategyCommon.cpp
@@ -41,7 +41,7 @@ void SliceStrategyCommon::freeSlice(auto_ptr<Slice> slice) {
   ASSERT(debugIsValidSlice(slice.get()));
 
   slice->clearIdealAndSubtract(); // To preserve memory.
-  noThrowPushBack(_sliceCache, slice);
+  noThrowPushBack(_sliceCache, std::move(slice));
 }
 
 void SliceStrategyCommon::setUseIndependence(bool use) {
@@ -101,9 +101,9 @@ void SliceStrategyCommon::pivotSplit(auto_ptr<Slice> slice) {
       slice->getIdeal().getGeneratorCount()) {
     // std::swap() may not work correctly on auto_ptr, so we have to
     // do the swap by hand.
-    auto_ptr<Slice> tmp = slice2;
-    slice2 = slice;
-    slice = tmp;
+    auto_ptr<Slice> tmp = std::move(slice2);
+    slice2 = std::move(slice);
+    slice = std::move(tmp);
   }
 
   _tasks.addTask(slice2.release());

--- a/src/StatisticsStrategy.cpp
+++ b/src/StatisticsStrategy.cpp
@@ -45,7 +45,7 @@ bool StatisticsStrategy::processSlice
   _internalTracker.preliminaryRecord(*slice);
   _leafTracker.preliminaryRecord(*slice);
 
-  bool wasBaseCase = _strategy->processSlice(tasks, slice);
+  bool wasBaseCase = _strategy->processSlice(tasks, std::move(slice));
 
   if (wasBaseCase)
     _leafTracker.commitRecord();
@@ -68,7 +68,7 @@ bool StatisticsStrategy::getUseSimplification() const {
 }
 
 void StatisticsStrategy::freeSlice(auto_ptr<Slice> slice) {
-  _strategy->freeSlice(slice);
+  _strategy->freeSlice(std::move(slice));
 }
 
 StatisticsStrategy::StatTracker::StatTracker(const string& title):

--- a/src/TotalDegreeCoefTermConsumer.cpp
+++ b/src/TotalDegreeCoefTermConsumer.cpp
@@ -25,7 +25,7 @@ TotalDegreeCoefTermConsumer::
 TotalDegreeCoefTermConsumer(auto_ptr<CoefBigTermConsumer> consumer,
                             const TermTranslator& translator):
   _consumer(*consumer),
-  _consumerOwner(consumer),
+  _consumerOwner(std::move(consumer)),
   _translator(translator) {
   ASSERT(_consumerOwner.get() != 0);
 }

--- a/src/TransformAction.cpp
+++ b/src/TransformAction.cpp
@@ -172,7 +172,7 @@ void TransformAction::perform() {
     idealFacade.takeProducts(ideals, *ideal);
 
     idealsDeleter.deleteElements();
-    exceptionSafePushBack(ideals, ideal);
+    exceptionSafePushBack(ideals, std::move(ideal));
   }
 
   for (size_t i = 0; i < ideals.size(); ++i) {

--- a/src/TranslatingCoefTermConsumer.cpp
+++ b/src/TranslatingCoefTermConsumer.cpp
@@ -31,7 +31,7 @@ TranslatingCoefTermConsumer::TranslatingCoefTermConsumer
 (auto_ptr<CoefBigTermConsumer> consumer, const TermTranslator& translator):
   _translator(translator),
   _consumer(*consumer),
-  _consumerOwner(consumer) {
+  _consumerOwner(std::move(consumer)) {
   ASSERT(_consumerOwner.get() != 0);
 }
 

--- a/src/TranslatingTermConsumer.cpp
+++ b/src/TranslatingTermConsumer.cpp
@@ -32,7 +32,7 @@ TranslatingTermConsumer::TranslatingTermConsumer
   _translator(translator),
   _consumer(*consumer) {
   ASSERT(consumer.get() != 0);
-  _consumerOwner = consumer;
+  _consumerOwner = std::move(consumer);
 }
 
 void TranslatingTermConsumer::beginConsumingList() {


### PR DESCRIPTION
This allows us to switch painlessly to unique_ptr when auto_ptr is removed from the language (which happens in C++17).

Tested by building `make test` with `-std=c++17 -Dauto_ptr=unique_ptr`.