### PR TITLE
Add libtool-compatible library versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,15 +270,19 @@ ifneq ($(wildcard bin/frobby),)
 	mkdir -p $(DESTDIR)$(MAN1DIR)
 	install -m 644 doc/frobby.1 $(DESTDIR)$(MAN1DIR)
 endif
-ifneq ($(wildcard bin/$(library)*),)
+ifneq ($(wildcard bin/libfrobby*),)
 	install -d $(DESTDIR)$(LIBDIR)
-	rm -f $(DESTDIR)$(LIBDIR)/$(library)*
-	install bin/$(library)* $(DESTDIR)$(LIBDIR)
-ifeq ($(MODE),shared)
+ifneq ($(wildcard bin/libfrobby.a),)
+	install bin/libfrobby.a $(DESTDIR)$(LIBDIR)
+endif
+ifneq ($(wildcard bin/libfrobby.so.$(FROBBY_VERSION)),)
+	install bin/libfrobby.so.$(FROBBY_VERSION) $(DESTDIR)$(LIBDIR)
 	cd $(DESTDIR)$(LIBDIR) && \
-		ln -s $(library).$(FROBBY_VERSION) \
-			$(library).$(FROBBY_SOVERSION) && \
-		ln -s $(library).$(FROBBY_VERSION) $(library)
+		rm -f libfrobby.so.$(FROBBY_SOVERSION) && \
+		ln -s libfrobby.so.$(FROBBY_VERSION) \
+			libfrobby.so.$(FROBBY_SOVERSION) && \
+		rm -f libfrobby.so && \
+		ln -s libfrobby.so.$(FROBBY_VERSION) libfrobby.so
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -236,9 +236,6 @@ ifeq ($(MODE), shared)
 	$(CXX) -shared -Wl,-soname,$(library).$(FROBBY_SOVERSION) \
 	-o bin/$(library).$(FROBBY_VERSION) $(ldflags) \
 	  $(patsubst $(outdir)main.o,,$(objs)) -lgmp -lgmpxx
-	cd bin && ln -s $(library).$(FROBBY_VERSION) \
-		$(library).$(FROBBY_SOVERSION) && \
-		ln -s $(library).$(FROBBY_VERSION) $(library)
 else
 	ar crs bin/$(library) $(patsubst $(outdir)main.o,,$(objs))
 	$(RANLIB) bin/$(library)
@@ -266,13 +263,27 @@ endif
 
 PREFIX ?= /usr/local
 MAN1DIR ?= $(PREFIX)/share/man/man1
+LIBDIR ?= $(PREFIX)/lib
 
 # Installation.
 install:
+ifneq ($(wildcard bin/frobby),)
 	install -d $(DESTDIR)$(BIN_INSTALL_DIR)
 	install bin/frobby $(DESTDIR)$(BIN_INSTALL_DIR)
 	mkdir -p $(DESTDIR)$(MAN1DIR)
 	install -m 644 doc/frobby.1 $(DESTDIR)$(MAN1DIR)
+endif
+ifneq ($(wildcard bin/$(library)*),)
+	install -d $(DESTDIR)$(LIBDIR)
+	rm -f $(DESTDIR)$(LIBDIR)/$(library)*
+	install bin/$(library)* $(DESTDIR)$(LIBDIR)
+ifeq ($(MODE),shared)
+	cd $(DESTDIR)$(LIBDIR) && \
+		ln -s $(library).$(FROBBY_VERSION) \
+			$(library).$(FROBBY_SOVERSION) && \
+		ln -s $(library).$(FROBBY_VERSION) $(library)
+endif
+endif
 
 # ***** Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -87,10 +87,6 @@ ifndef CXX
   CXX      = "g++"
 endif
 
-ifndef BIN_INSTALL_DIR
-  BIN_INSTALL_DIR = "/usr/local/bin/"
-endif
-
 cxxflags = $(CXXFLAGS) $(CPPFLAGS) -I $(GMP_INC_DIR) -Wno-uninitialized -Wno-unused-parameter
 program = frobby
 library = libfrobby.a
@@ -262,14 +258,15 @@ endif
 -include $(objs:.o=.d)
 
 PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
 MAN1DIR ?= $(PREFIX)/share/man/man1
 LIBDIR ?= $(PREFIX)/lib
 
 # Installation.
 install:
 ifneq ($(wildcard bin/frobby),)
-	install -d $(DESTDIR)$(BIN_INSTALL_DIR)
-	install bin/frobby $(DESTDIR)$(BIN_INSTALL_DIR)
+	install -d $(DESTDIR)$(BINDIR)
+	install bin/frobby $(DESTDIR)$(BINDIR)
 	mkdir -p $(DESTDIR)$(MAN1DIR)
 	install -m 644 doc/frobby.1 $(DESTDIR)$(MAN1DIR)
 endif

--- a/README
+++ b/README
@@ -12,4 +12,5 @@ To bump the version number, change it in these places:
    test/messages/help-noparam.err
         Frobby version 0.9.5 Copyright (C) 2007 Bjarke Hammersholt Roune
 
-
+Also, update the library version by setting FROBBY_CURRENT, FROBBY_REVISION,
+and FROBBY_AGE as outlined in Makefile.


### PR DESCRIPTION
We start at 1:0:0 since the Debian package has been using 0:0:0 prior to the `constants::version` → `frobby_version` interface change in #5.  See Debian bug [#992432](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=992432).

Up to this point, I've just been setting the library version in the Debian packaging, but it would be better if this were taken care of upstream.

