### PR TITLE
Define RANLIB Makefile variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,8 @@ endif
 sources = $(patsubst %.cpp, src/%.cpp, $(rawSources))
 objs    = $(patsubst %.cpp, $(outdir)%.o, $(rawSources))
 
+RANLIB = ranlib
+
 # ***** Compilation
 
 .PHONY: all depend clean bin/$(program) test library distribution clear fixspace


### PR DESCRIPTION
If it's not defined, then when building the static library, we get:

    bin/libfrobby.a: Permission denied