### PR TITLE
Change /usr/bin/env to env in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,9 +249,9 @@ $(outdir)%.o: src/%.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) ${cxxflags} -c $< -o $@
 	$(CXX) $(cxxflags) -MM -c $< > $(@:.o=.d).tmp
-# using /usr/bin/env echo to get the non-built-in echo on OS X, since
+# using env echo to get the non-built-in echo on OS X, since
 # the built-in one does not understand the parameter -n.
-	@/usr/bin/env echo -n "$(dir $@)" > $(@:.o=.d)
+	@env echo -n "$(dir $@)" > $(@:.o=.d)
 	@cat $(@:.o=.d).tmp >> $(@:.o=.d)
 	@sed -e 's/.*://' -e 's/\\$$//' < $(@:.o=.d).tmp | fmt -1 | \
 	  sed -e 's/^ *//' -e 's/$$/:/' >> $(@:.o=.d)


### PR DESCRIPTION
`env` is a coreutil, so I think it should be present in a standard (on `$PATH`) location on any system that already has `cat`, `echo`, etc.  `/usr/bin/env` is technically more redundant than `env` by itself, but using the latter is no different than using `cat`, `echo`, and `mkdir` by themselves.  The advantage is that this is more convenient in environments where `env` *is* in a non-standard location (e.g. an isolated build sandbox), and trusts the user to know where to point to find it.