### PR TITLE
Darwin fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,12 @@ objs    = $(patsubst %.cpp, $(outdir)%.o, $(rawSources))
 
 RANLIB = ranlib
 
+internalNameFlag=-soname
+OS=$(shell uname -s)
+ifeq ($(OS), Darwin)
+  internalNameFlag=-install_name
+endif
+
 # ***** Compilation
 
 .PHONY: all depend clean bin/$(program) test library distribution clear fixspace
@@ -234,7 +240,7 @@ library: bin/$(library)
 bin/$(library): $(objs) | bin/
 	rm -f bin/$(library)
 ifeq ($(MODE), shared)
-	$(CXX) -shared -Wl,-soname,$(library).$(FROBBY_SOVERSION) \
+	$(CXX) -shared -Wl,$(internalNameFlag),$(library).$(FROBBY_SOVERSION) \
 	-o bin/$(library).$(FROBBY_VERSION) $(ldflags) \
 	  $(patsubst $(outdir)main.o,,$(objs)) -lgmp -lgmpxx
 else


### PR DESCRIPTION
This is to address #36.  It's just a check for Darwin systems and a new `internalNameFlag` variable to account for the difference between `-soname` on Linux and `-install_name` on Darwin.